### PR TITLE
Remove a call to the non-existing "wrap" method

### DIFF
--- a/moxy.py
+++ b/moxy.py
@@ -481,9 +481,7 @@ def make_response(response: Union[str,dict], status, content, headers) -> http.H
         headers.update(merge_headers)
     status = response.get("status", status)
     ctx.log.debug("Response {}: headers={} content={}".format(status, headers, content))
-    return http.HTTPResponse.wrap(
-        net.http.Response.make(status, content, headers),
-    )
+    return net.http.Response.make(status, content, headers)
 
 def extract_regex_paths(config: OrderedDict) -> OrderedDict:
     """


### PR DESCRIPTION
I was constantly getting the following error in the event log when I tried to substitute a response:
```
error: Addon error: Traceback (most recent call last):
  File "moxy.py", line 783, in response
    flow.response = make_response(response, flow.response.status_code, flow.response.content, flow.response.headers)
  File "moxy.py", line 484, in make_response
    return http.HTTPResponse.wrap(
AttributeError: type object 'Response' has no attribute 'wrap'
```

It seems the `wrap` method was deleted recently according to [this commit](https://github.com/mitmproxy/mitmproxy/commit/5af57cfa996fcd27a395064a5e5507f9357d0d5b#diff-2c66d694bc6807be9f0854acc8dd3533319338f55b8bf2a289f5e02dd8f36689L125).

I have no Python development experience but still wanted to share the solution that helped me.